### PR TITLE
Update Permute to v2

### DIFF
--- a/hash/skyscraper.go
+++ b/hash/skyscraper.go
@@ -28,7 +28,7 @@ func (s *SkyscraperState) Initialize(iv [32]byte) {
 }
 
 func (s *SkyscraperState) Permute() {
-	s.skyscraper.Permute(&s.s)
+	s.skyscraper.PermuteV2(&s.s)
 }
 
 func (s *SkyscraperState) State() []frontend.Variable {


### PR DESCRIPTION
This PR is dependent on https://github.com/reilabs/gnark-skyscraper/pull/4 and updates the existing [Permute](https://github.com/reilabs/gnark-nimue/blob/main/hash/skyscraper.go#L30) function in `/hash/skyscraper.go` to use `PermuteV2`. It is required for https://github.com/worldfnd/provekit/pull/142.

The code has been tested to work e2e with `gnark-whir`.